### PR TITLE
Update label_image.py

### DIFF
--- a/scripts/label_image.py
+++ b/scripts/label_image.py
@@ -23,6 +23,7 @@ import time
 
 import numpy as np
 import tensorflow as tf
+tf.compat.v1.disable_eager_execution()
 
 def load_graph(model_file):
   graph = tf.Graph()


### PR DESCRIPTION
Running this with TensorFlow 2.4 on a Raspberry Pi I was getting a "RuntimeError: The Session graph is empty" notice and the label operation wouldn't work.  I tried various things to fix it, but the only thing that seemed to work was disabling eager execution.  I'm not an expert with TensorFlow so I'm open to other solutions if this is a problem.  Just sharing that in my case it resolved the problem and allowed image classification to work again.